### PR TITLE
Improve SendMessage sales pitch for subscribed users

### DIFF
--- a/src/components/SendMessage.tsx
+++ b/src/components/SendMessage.tsx
@@ -398,10 +398,22 @@ export default function SendMessage({
               </Button>
             </CardHeader>
             <CardContent className="p-3 pt-1 pb-2 text-sm">
-              Subscribe or buy tokens to keep using{" "}
-              <Badge variant="outline" className="font-medium ml-1">
-                {preferences.preferences?.mainModel || ""}
-              </Badge>
+              {user?.data?.planTier ? (
+                <>
+                  You've run out of tokens. Upgrade your plan or buy extra
+                  tokens to keep using{" "}
+                  <Badge variant="outline" className="font-medium ml-1">
+                    {preferences.preferences?.mainModel || ""}
+                  </Badge>
+                </>
+              ) : (
+                <>
+                  Subscribe or buy tokens to keep using{" "}
+                  <Badge variant="outline" className="font-medium ml-1">
+                    {preferences.preferences?.mainModel || ""}
+                  </Badge>
+                </>
+              )}
             </CardContent>
             <CardFooter className="flex flex-col gap-2 p-3 pt-0">
               <Button
@@ -428,20 +440,31 @@ export default function SendMessage({
                 </Button>
               )}
 
+              {user?.data?.planTier && user?.data?.planTier < 3 && (
+                <Button
+                  variant="default"
+                  size="sm"
+                  className="w-full justify-start"
+                  onClick={openSubscriptionsTab}
+                >
+                  <Crown className="mr-2 h-4 w-4" /> Manage Subscription
+                </Button>
+              )}
+
               <Button
                 variant="outline"
                 size="sm"
                 className="w-full justify-start"
                 onClick={() => {
                   if (user?.data?.planTier) {
-                    openSubscriptionsTab()
+                    openTokenModal()
                   } else {
                     openTokenModal()
                   }
                 }}
               >
                 <CreditCard className="mr-2 h-4 w-4" />
-                {user?.data?.planTier ? "Upgrade Plan" : "Buy Tokens"}
+                {user?.data?.planTier ? "Purchase Tokens" : "Buy Tokens"}
               </Button>
             </CardFooter>
           </Card>


### PR DESCRIPTION
Resolves #515

This PR improves the SendMessage sales pitch to provide different messaging for subscribed users vs free users when they run out of tokens.

## Changes
- Added conditional messaging based on user subscription status
- For subscribed users: "You've run out of tokens. Upgrade your plan or buy extra tokens to keep using [model]"
- For free users: Keep original message "Subscribe or buy tokens to keep using [model]"
- Added "Manage Subscription" button for subscribed users (planTier 1-2 only)
- Tier 3 users only see "Purchase Tokens" button (no manage subscription button)
- Both free and subscribed users see "Purchase Tokens"/"Buy Tokens" button

## User Experience
- Free users (planTier = 0): See "Subscribe to a Plan" and "Buy Tokens" buttons
- Subscribed users (planTier 1-2): See "Manage Subscription" and "Purchase Tokens" buttons
- Premium users (planTier 3): Only see "Purchase Tokens" button

Generated with [Claude Code](https://claude.ai/code)