### PR TITLE
Omar/button organization

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ditto-pwa",
-  "version": "0.15.3",
+  "version": "0.15.4",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,7 +14,7 @@ import { BalanceProvider } from "@/hooks/useBalance"
 import { MemoryCountProvider } from "@/hooks/useMemoryCount"
 import { ModelPreferencesProvider } from "@/hooks/useModelPreferences"
 import { ImageViewerProvider } from "@/hooks/useImageViewer"
-import { PlatformProvider } from "@/hooks/usePlatform"
+import { PlatformProvider, usePlatformContext } from "@/hooks/usePlatform"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools"
 import { ModalProvider, ModalRegistry } from "@/hooks/useModal"
@@ -125,6 +125,25 @@ const modalRegistry: ModalRegistry = {
   },
 } as const
 
+// Component to handle dynamic toast offset based on PWA vs web
+const ToasterWrapper = () => {
+  const { isPWA } = usePlatformContext()
+  
+  // PWA needs more offset to account for different top bar behavior
+  // Web uses 80px, PWA needs more space (120px for Android PWA)
+  const offset = isPWA ? 120 : 80
+  
+  return createPortal(
+    <Toaster
+      position="top-center"
+      closeButton
+      richColors
+      offset={offset}
+    />,
+    document.getElementById("toast-root")!
+  )
+}
+
 function App() {
   return (
     <QueryClientProvider client={queryClient}>
@@ -154,15 +173,7 @@ function App() {
                                         </AppErrorBoundary>
                                         <UpdateNotification />
 
-                                        {createPortal(
-                                          <Toaster
-                                            position="top-center"
-                                            closeButton
-                                            richColors
-                                            offset={80}
-                                          />,
-                                          document.getElementById("toast-root")!
-                                        )}
+                                        <ToasterWrapper />
                                         <ReactQueryDevtools
                                           buttonPosition="top-left"
                                           initialIsOpen={false}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -128,18 +128,13 @@ const modalRegistry: ModalRegistry = {
 // Component to handle dynamic toast offset based on PWA vs web
 const ToasterWrapper = () => {
   const { isPWA } = usePlatformContext()
-  
+
   // PWA needs more offset to account for different top bar behavior
   // Web uses 80px, PWA needs more space (120px for Android PWA)
   const offset = isPWA ? 120 : 80
-  
+
   return createPortal(
-    <Toaster
-      position="top-center"
-      closeButton
-      richColors
-      offset={offset}
-    />,
+    <Toaster position="top-center" closeButton richColors offset={offset} />,
     document.getElementById("toast-root")!
   )
 }

--- a/src/components/ChatMessage.tsx
+++ b/src/components/ChatMessage.tsx
@@ -51,8 +51,6 @@ const toolLabels: Record<string, { color: string; text: string }> = {
   home: { color: "#F44336", text: "Home" },
 }
 
-// Note: We've migrated from the custom AvatarActionMenu to shadcn's DropdownMenu
-
 interface ChatMessageProps {
   content: string
   timestamp: number | Date
@@ -219,7 +217,7 @@ export default function ChatMessage({
                 <MarkdownRenderer content={content} />
               </div>
             )}
-            {/* Timestamp and Sync Row */}
+            {/* Timestamp and Action Buttons Row */}
             <div className="flex items-center mt-2">
               {/* Sync Indicator */}
               {!isUser && showSyncIndicator && (
@@ -228,60 +226,102 @@ export default function ChatMessage({
                 </div>
               )}
 
-              {/* Subjects Dropdown - only show if not syncing */}
+              {/* Action buttons - only show if not syncing */}
               {!isOptimistic && !showSyncIndicator && (
-                <DropdownMenu
-                  onOpenChange={(open) => {
-                    if (open) {
-                      handleFetchSubjects()
-                    }
-                  }}
-                >
-                  <DropdownMenuTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="h-6 w-6 text-foreground/70 hover:bg-background/20"
-                    >
-                      {isLoadingSubjects ? (
-                        <Loader2 className="h-4 w-4 animate-spin" />
-                      ) : (
-                        <Tags className="h-4 w-4" />
-                      )}
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent className="w-60">
-                    <DropdownMenuLabel>Linked Subjects</DropdownMenuLabel>
-                    <DropdownMenuSeparator />
-                    <div className="p-2 space-y-2">
-                      {errorSubjects && (
-                        <p className="text-xs text-destructive">
-                          {errorSubjects}
-                        </p>
-                      )}
-                      {subjects.length > 0
-                        ? subjects.map((s, i) => (
-                            <div
-                              key={i}
-                              className="flex justify-between items-center"
-                            >
-                              <span className="text-sm font-medium">
-                                {s.subject_text}
-                              </span>
-                              <span className="text-xs text-muted-foreground">
-                                {s.pair_count} pairs
-                              </span>
-                            </div>
-                          ))
-                        : !errorSubjects &&
-                          !isLoadingSubjects && (
-                            <p className="text-xs text-muted-foreground">
-                              No subjects found.
-                            </p>
-                          )}
-                    </div>
-                  </DropdownMenuContent>
-                </DropdownMenu>
+                <div className="flex items-center gap-1">
+                  {/* Subjects Dropdown */}
+                  <DropdownMenu
+                    onOpenChange={(open) => {
+                      if (open) {
+                        handleFetchSubjects()
+                      }
+                    }}
+                  >
+                    <DropdownMenuTrigger asChild>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-6 w-6 text-foreground/70 hover:bg-background/20"
+                      >
+                        {isLoadingSubjects ? (
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                        ) : (
+                          <Tags className="h-4 w-4" />
+                        )}
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent className="w-60">
+                      <DropdownMenuLabel>Linked Subjects</DropdownMenuLabel>
+                      <DropdownMenuSeparator />
+                      <div className="p-2 space-y-2">
+                        {errorSubjects && (
+                          <p className="text-xs text-destructive">
+                            {errorSubjects}
+                          </p>
+                        )}
+                        {subjects.length > 0
+                          ? subjects.map((s, i) => (
+                              <div
+                                key={i}
+                                className="flex justify-between items-center"
+                              >
+                                <span className="text-sm font-medium">
+                                  {s.subject_text}
+                                </span>
+                                <span className="text-xs text-muted-foreground">
+                                  {s.pair_count} pairs
+                                </span>
+                              </div>
+                            ))
+                          : !errorSubjects &&
+                            !isLoadingSubjects && (
+                              <p className="text-xs text-muted-foreground">
+                                No subjects found.
+                              </p>
+                            )}
+                      </div>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+
+                  {/* Copy Button */}
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-6 w-6 text-foreground/70 hover:bg-background/20"
+                    onClick={() => {
+                      triggerLightHaptic()
+                      menuProps.onCopy()
+                    }}
+                  >
+                    <Copy className="h-4 w-4" />
+                  </Button>
+
+                  {/* Memories Button */}
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-6 w-6 text-foreground/70 hover:bg-background/20"
+                    onClick={() => {
+                      triggerLightHaptic()
+                      menuProps.onShowMemories()
+                    }}
+                  >
+                    <Brain className="h-4 w-4" />
+                  </Button>
+
+                  {/* Delete Button */}
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-6 w-6 text-foreground/70 hover:bg-background/20 hover:text-destructive"
+                    onClick={() => {
+                      triggerLightHaptic()
+                      menuProps.onDelete()
+                    }}
+                  >
+                    <Trash className="h-4 w-4" />
+                  </Button>
+                </div>
               )}
 
               {/* Timestamp */}
@@ -297,55 +337,17 @@ export default function ChatMessage({
         </Card>
       </div>
 
-      {/* Avatar below bubble */}
+      {/* Static Avatar below bubble (no dropdown functionality) */}
       <div className="mt-1.5 mb-1.5">
-        {" "}
-        {/* important margin for avatar spacing */}
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Avatar
-              className="h-7 w-7 cursor-pointer hover:scale-110 hover:ring-blue-500 hover:shadow-md hover:shadow-blue-500/80 transition-all ring-1 ring-blue-500/70 shadow-sm shadow-blue-500/50"
-              onPointerDown={triggerLightHaptic}
-            >
-              <AvatarImage
-                src={avatar}
-                alt={isUser ? "User Avatar" : "Ditto Avatar"}
-                className="object-cover"
-                draggable={false}
-              />
-              <AvatarFallback>{isUser ? "U" : "D"}</AvatarFallback>
-            </Avatar>
-          </DropdownMenuTrigger>
-          {menuProps && (
-            <DropdownMenuContent
-              align={isUser ? "end" : "start"}
-              className="w-auto"
-            >
-              <DropdownMenuItem
-                onPointerDown={triggerLightHaptic}
-                onClick={menuProps.onCopy}
-              >
-                <Copy className="mr-2 h-4 w-4" />
-                <span>Copy</span>
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onPointerDown={triggerLightHaptic}
-                onClick={menuProps.onShowMemories}
-              >
-                <Brain className="mr-2 h-4 w-4" />
-                <span>Memories</span>
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onPointerDown={triggerLightHaptic}
-                onClick={menuProps.onDelete}
-                className="text-destructive focus:text-destructive"
-              >
-                <Trash className="mr-2 h-4 w-4" />
-                <span>Delete</span>
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          )}
-        </DropdownMenu>
+        <Avatar className="h-7 w-7 ring-1 ring-blue-500/70 shadow-sm shadow-blue-500/50">
+          <AvatarImage
+            src={avatar}
+            alt={isUser ? "User Avatar" : "Ditto Avatar"}
+            className="object-cover"
+            draggable={false}
+          />
+          <AvatarFallback>{isUser ? "U" : "D"}</AvatarFallback>
+        </Avatar>
       </div>
     </div>
   )

--- a/src/components/ChatMessage.tsx
+++ b/src/components/ChatMessage.tsx
@@ -17,7 +17,6 @@ import { Card, CardContent } from "@/components/ui/card"
 import {
   DropdownMenu,
   DropdownMenuContent,
-  DropdownMenuItem,
   DropdownMenuTrigger,
   DropdownMenuLabel,
   DropdownMenuSeparator,
@@ -217,137 +216,152 @@ export default function ChatMessage({
                 <MarkdownRenderer content={content} />
               </div>
             )}
-            {/* Timestamp and Action Buttons Row */}
-            <div className="flex items-center mt-2">
-              {/* Sync Indicator */}
-              {!isUser && showSyncIndicator && (
+            {/* Sync Indicator - keep inside bubble when syncing */}
+            {!isUser && showSyncIndicator && (
+              <div className="flex items-center mt-2">
                 <div className="text-xs opacity-70">
                   <SyncIndicator isVisible={true} currentStage={syncStage} />
                 </div>
-              )}
-
-              {/* Action buttons - only show if not syncing */}
-              {!isOptimistic && !showSyncIndicator && (
-                <div className="flex items-center gap-1">
-                  {/* Subjects Dropdown */}
-                  <DropdownMenu
-                    onOpenChange={(open) => {
-                      if (open) {
-                        handleFetchSubjects()
-                      }
-                    }}
-                  >
-                    <DropdownMenuTrigger asChild>
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        className="h-6 w-6 text-foreground/70 hover:bg-background/20"
-                      >
-                        {isLoadingSubjects ? (
-                          <Loader2 className="h-4 w-4 animate-spin" />
-                        ) : (
-                          <Tags className="h-4 w-4" />
-                        )}
-                      </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent className="w-60">
-                      <DropdownMenuLabel>Linked Subjects</DropdownMenuLabel>
-                      <DropdownMenuSeparator />
-                      <div className="p-2 space-y-2">
-                        {errorSubjects && (
-                          <p className="text-xs text-destructive">
-                            {errorSubjects}
-                          </p>
-                        )}
-                        {subjects.length > 0
-                          ? subjects.map((s, i) => (
-                              <div
-                                key={i}
-                                className="flex justify-between items-center"
-                              >
-                                <span className="text-sm font-medium">
-                                  {s.subject_text}
-                                </span>
-                                <span className="text-xs text-muted-foreground">
-                                  {s.pair_count} pairs
-                                </span>
-                              </div>
-                            ))
-                          : !errorSubjects &&
-                            !isLoadingSubjects && (
-                              <p className="text-xs text-muted-foreground">
-                                No subjects found.
-                              </p>
-                            )}
-                      </div>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-
-                  {/* Copy Button */}
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="h-6 w-6 text-foreground/70 hover:bg-background/20"
-                    onClick={() => {
-                      triggerLightHaptic()
-                      menuProps.onCopy()
-                    }}
-                  >
-                    <Copy className="h-4 w-4" />
-                  </Button>
-
-                  {/* Memories Button */}
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="h-6 w-6 text-foreground/70 hover:bg-background/20"
-                    onClick={() => {
-                      triggerLightHaptic()
-                      menuProps.onShowMemories()
-                    }}
-                  >
-                    <Brain className="h-4 w-4" />
-                  </Button>
-
-                  {/* Delete Button */}
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="h-6 w-6 text-foreground/70 hover:bg-background/20 hover:text-destructive"
-                    onClick={() => {
-                      triggerLightHaptic()
-                      menuProps.onDelete()
-                    }}
-                  >
-                    <Trash className="h-4 w-4" />
-                  </Button>
-                </div>
-              )}
-
-              {/* Timestamp */}
-              <div className="ml-auto text-xs opacity-70">
-                {isOptimistic
-                  ? content === ""
-                    ? "Thinking..."
-                    : "Streaming..."
-                  : formatTimestamp(timestamp)}
               </div>
-            </div>
+            )}
           </CardContent>
         </Card>
       </div>
 
-      {/* Static Avatar below bubble (no dropdown functionality) */}
-      <div className="mt-1.5 mb-1.5">
-        <Avatar className="h-7 w-7 ring-1 ring-blue-500/70 shadow-sm shadow-blue-500/50">
-          <AvatarImage
-            src={avatar}
-            alt={isUser ? "User Avatar" : "Ditto Avatar"}
-            className="object-cover"
-            draggable={false}
-          />
-          <AvatarFallback>{isUser ? "U" : "D"}</AvatarFallback>
-        </Avatar>
+      {/* Gutter area with Avatar, Action Buttons, and Timestamp */}
+      <div className="mt-1.5 mb-1.5 flex items-center gap-2 w-full">
+        {/* Avatar */}
+        <div className="flex-shrink-0">
+          <Avatar className="h-7 w-7 ring-1 ring-blue-500/70 shadow-sm shadow-blue-500/50">
+            <AvatarImage
+              src={avatar}
+              alt={isUser ? "User Avatar" : "Ditto Avatar"}
+              className="object-cover"
+              draggable={false}
+            />
+            <AvatarFallback>{isUser ? "U" : "D"}</AvatarFallback>
+          </Avatar>
+        </div>
+
+        {/* Action buttons and timestamp - only show if not syncing */}
+        {!isOptimistic && !showSyncIndicator && (
+          <div className="flex items-center gap-1.5 flex-1">
+            {/* Subjects Dropdown */}
+            <DropdownMenu
+              onOpenChange={(open) => {
+                if (open) {
+                  handleFetchSubjects()
+                }
+              }}
+            >
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8 text-foreground/70 hover:bg-background/20"
+                  aria-label="View linked subjects"
+                >
+                  {isLoadingSubjects ? (
+                    <Loader2 className="h-5 w-5 animate-spin" />
+                  ) : (
+                    <Tags className="h-5 w-5" />
+                  )}
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent className="w-60">
+                <DropdownMenuLabel>Linked Subjects</DropdownMenuLabel>
+                <DropdownMenuSeparator />
+                <div className="p-2 space-y-2">
+                  {errorSubjects && (
+                    <p className="text-xs text-destructive">{errorSubjects}</p>
+                  )}
+                  {subjects.length > 0
+                    ? subjects.map((s, i) => (
+                        <div
+                          key={i}
+                          className="flex justify-between items-center"
+                        >
+                          <span className="text-sm font-medium">
+                            {s.subject_text}
+                          </span>
+                          <span className="text-xs text-muted-foreground">
+                            {s.pair_count} pairs
+                          </span>
+                        </div>
+                      ))
+                    : !errorSubjects &&
+                      !isLoadingSubjects && (
+                        <p className="text-xs text-muted-foreground">
+                          No subjects found.
+                        </p>
+                      )}
+                </div>
+              </DropdownMenuContent>
+            </DropdownMenu>
+
+            {/* Copy Button */}
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8 text-foreground/70 hover:bg-background/20"
+              onClick={() => {
+                triggerLightHaptic()
+                menuProps.onCopy()
+              }}
+              aria-label="Copy message"
+            >
+              <Copy className="h-5 w-5" />
+            </Button>
+
+            {/* Memories Button */}
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8 text-foreground/70 hover:bg-background/20"
+              onClick={() => {
+                triggerLightHaptic()
+                menuProps.onShowMemories()
+              }}
+              aria-label="Show memories"
+            >
+              <Brain className="h-5 w-5" />
+            </Button>
+
+            {/* Delete Button */}
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8 text-foreground/70 hover:bg-background/20 hover:text-destructive"
+              onClick={() => {
+                triggerLightHaptic()
+                menuProps.onDelete()
+              }}
+              aria-label="Delete message"
+            >
+              <Trash className="h-5 w-5" />
+            </Button>
+
+            {/* Timestamp */}
+            <div className="ml-auto text-xs opacity-70 flex-shrink-0">
+              {isOptimistic
+                ? content === ""
+                  ? "Thinking..."
+                  : "Streaming..."
+                : formatTimestamp(timestamp)}
+            </div>
+          </div>
+        )}
+
+        {/* Timestamp only (when syncing or optimistic) */}
+        {(isOptimistic || showSyncIndicator) && (
+          <div className="ml-auto text-xs opacity-70 flex-shrink-0">
+            {isOptimistic
+              ? content === ""
+                ? "Thinking..."
+                : "Streaming..."
+              : formatTimestamp(timestamp)}
+          </div>
+        )}
       </div>
     </div>
   )

--- a/src/components/ChatMessage.tsx
+++ b/src/components/ChatMessage.tsx
@@ -3,7 +3,7 @@ import MarkdownRenderer from "./MarkdownRenderer"
 import { DEFAULT_USER_AVATAR, DITTO_AVATAR } from "@/constants"
 import { useAuth } from "@/hooks/useAuth"
 import { useUserAvatar } from "@/hooks/useUserAvatar"
-import { Copy, Brain, Trash, Tags, Loader2 } from "lucide-react"
+import { Copy, Brain, Trash, Tags, Loader2, Network } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { useFontSize } from "@/hooks/useFontSize"
 import SyncIndicator from "./SyncIndicator"
@@ -332,7 +332,7 @@ export default function ChatMessage({
               <Copy className="h-5 w-5" />
             </Button>
 
-            {/* Memories Button */}
+            {/* Memory Graph Viewer Button */}
             <Button
               variant="ghost"
               size="icon"
@@ -341,9 +341,9 @@ export default function ChatMessage({
                 triggerLightHaptic()
                 menuProps.onShowMemories()
               }}
-              aria-label="Show memories"
+              aria-label="Show memory graph"
             >
-              <Brain className="h-5 w-5" />
+              <Network className="h-5 w-5" />
             </Button>
 
             {/* Delete Button */}

--- a/src/components/ChatMessage.tsx
+++ b/src/components/ChatMessage.tsx
@@ -229,7 +229,12 @@ export default function ChatMessage({
       </div>
 
       {/* Gutter area with Avatar, Action Buttons, and Timestamp */}
-      <div className="mt-1.5 mb-1.5 flex items-center gap-2 w-full">
+      <div
+        className={cn(
+          "mt-1.5 mb-1.5 flex items-center gap-2 w-full",
+          isUser ? "flex-row-reverse" : "flex-row"
+        )}
+      >
         {/* Avatar */}
         <div className="flex-shrink-0">
           <Avatar className="h-7 w-7 ring-1 ring-blue-500/70 shadow-sm shadow-blue-500/50">
@@ -245,7 +250,21 @@ export default function ChatMessage({
 
         {/* Action buttons and timestamp - only show if not syncing */}
         {!isOptimistic && !showSyncIndicator && (
-          <div className="flex items-center gap-1.5 flex-1">
+          <div
+            className={cn(
+              "flex items-center gap-1.5 flex-1",
+              isUser ? "flex-row-reverse" : "flex-row"
+            )}
+          >
+            {/* Timestamp */}
+            <div className="text-xs opacity-70 flex-shrink-0">
+              {isOptimistic
+                ? content === ""
+                  ? "Thinking..."
+                  : "Streaming..."
+                : formatTimestamp(timestamp)}
+            </div>
+
             {/* Subjects Dropdown */}
             <DropdownMenu
               onOpenChange={(open) => {
@@ -340,21 +359,12 @@ export default function ChatMessage({
             >
               <Trash className="h-5 w-5" />
             </Button>
-
-            {/* Timestamp */}
-            <div className="ml-auto text-xs opacity-70 flex-shrink-0">
-              {isOptimistic
-                ? content === ""
-                  ? "Thinking..."
-                  : "Streaming..."
-                : formatTimestamp(timestamp)}
-            </div>
           </div>
         )}
 
         {/* Timestamp only (when syncing or optimistic) */}
         {(isOptimistic || showSyncIndicator) && (
-          <div className="ml-auto text-xs opacity-70 flex-shrink-0">
+          <div className="text-xs opacity-70 flex-shrink-0">
             {isOptimistic
               ? content === ""
                 ? "Thinking..."

--- a/src/components/SendMessage.tsx
+++ b/src/components/SendMessage.tsx
@@ -97,7 +97,6 @@ export default function SendMessage({
   const modal = useModal()
   const openTokenModal = modal.createOpenHandler("tokenCheckout")
   const openSubscriptionsTab = modal.createOpenHandler("settings", "general")
-  const openMemoriesOverlay = modal.createOpenHandler("memories")
   const triggerLightHaptic = () => triggerHaptic(HapticPattern.Light)
 
   const { user: authUser } = useAuth()
@@ -507,26 +506,6 @@ export default function SendMessage({
                 </DropdownMenu>
               </div>
 
-              {/* Center - Memories button */}
-              <div className="absolute left-1/2 -translate-x-1/2">
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      onClick={() => {
-                        triggerLightHaptic()
-                        openMemoriesOverlay()
-                      }}
-                      aria-label="Open memories"
-                      className="h-10 w-10 rounded-full bg-background ring-1 ring-blue-500/70 shadow-sm shadow-blue-500/50 hover:scale-110 hover:ring-blue-500 hover:shadow-md hover:shadow-blue-500/80 transition-all"
-                    >
-                      <Brain className="h-5 w-5" />
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent>Memories</TooltipContent>
-                </Tooltip>
-              </div>
 
               <div className="flex items-center gap-1.5">
                 {/* Send/Stop button */}

--- a/src/components/SendMessage.tsx
+++ b/src/components/SendMessage.tsx
@@ -506,7 +506,6 @@ export default function SendMessage({
                 </DropdownMenu>
               </div>
 
-
               <div className="flex items-center gap-1.5">
                 {/* Send/Stop button */}
                 <Tooltip>

--- a/src/components/SendMessage.tsx
+++ b/src/components/SendMessage.tsx
@@ -9,8 +9,6 @@ import {
   CreditCard,
   Crown,
   Bolt,
-  Settings,
-  MessageCircle,
   X,
   Square,
   Brain,
@@ -33,7 +31,6 @@ import { usePromptStorage } from "@/hooks/usePromptStorage"
 import { useUser } from "@/hooks/useUser"
 import { useMemorySyncContext } from "@/contexts/MemorySyncContext"
 import { useIOSDetection } from "@/hooks/useIOSDetection"
-import { Avatar, AvatarImage } from "@/components/ui/avatar"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
@@ -97,14 +94,10 @@ export default function SendMessage({
   const { clearPrompt } = usePromptStorage()
   const { triggerSync } = useMemorySyncContext()
 
-  const logoButtonRef = useRef<HTMLDivElement>(null)
-  const [isMenuOpen, setIsMenuOpen] = useState(false)
   const modal = useModal()
-  const openSettingsModal = modal.createOpenHandler("settings")
-  const openSubscriptionsTab = modal.createOpenHandler("settings", "general")
-  const openFeedbackModal = modal.createOpenHandler("feedback")
-  const openMemoriesOverlay = modal.createOpenHandler("memories")
   const openTokenModal = modal.createOpenHandler("tokenCheckout")
+  const openSubscriptionsTab = modal.createOpenHandler("settings", "general")
+  const openMemoriesOverlay = modal.createOpenHandler("memories")
   const triggerLightHaptic = () => triggerHaptic(HapticPattern.Light)
 
   const { user: authUser } = useAuth()
@@ -144,10 +137,6 @@ export default function SendMessage({
       if (event) event.preventDefault()
       if (isWaitingForResponse) return
       if (message === "" && !image) return
-
-      if (isMenuOpen) {
-        setIsMenuOpen(false)
-      }
 
       setIsWaitingForResponse(true)
       try {
@@ -250,7 +239,6 @@ export default function SendMessage({
       isWaitingForResponse,
       message,
       image,
-      isMenuOpen,
       setIsWaitingForResponse,
       preferences.preferences,
       clearPrompt,
@@ -341,11 +329,6 @@ export default function SendMessage({
 
   const handleCameraClick = () => {
     onCameraOpen()
-  }
-
-  const handleLogoClick = () => {
-    // Simple toggle behavior for all platforms
-    setIsMenuOpen(!isMenuOpen)
   }
 
   // Add auto-resize function
@@ -524,59 +507,25 @@ export default function SendMessage({
                 </DropdownMenu>
               </div>
 
-              {/* Center Ditto logo dropdown */}
+              {/* Center - Memories button */}
               <div className="absolute left-1/2 -translate-x-1/2">
-                <DropdownMenu>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <DropdownMenuTrigger asChild>
-                        <Avatar
-                          ref={logoButtonRef as React.RefObject<HTMLDivElement>}
-                          className="h-10 w-10 cursor-pointer hover:scale-110 hover:ring-blue-500 hover:shadow-md hover:shadow-blue-500/80 transition-all ring-1 ring-blue-500/70 shadow-sm shadow-blue-500/50"
-                          onClick={handleLogoClick}
-                          onPointerDown={triggerLightHaptic}
-                        >
-                          <AvatarImage
-                            src={DITTO_LOGO}
-                            alt="Ditto"
-                            className="h-10 w-10 rounded-full rainbow-gradient"
-                          />
-                        </Avatar>
-                      </DropdownMenuTrigger>
-                    </TooltipTrigger>
-                    <TooltipContent>Menu</TooltipContent>
-                  </Tooltip>
-                  <DropdownMenuContent
-                    side="top"
-                    align="center"
-                    className="w-40 p-2"
-                  >
-                    <DropdownMenuItem
-                      onClick={openMemoriesOverlay}
-                      onPointerDown={triggerLightHaptic}
-                      className="flex items-center py-3"
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => {
+                        triggerLightHaptic()
+                        openMemoriesOverlay()
+                      }}
+                      aria-label="Open memories"
+                      className="h-10 w-10 rounded-full bg-background ring-1 ring-blue-500/70 shadow-sm shadow-blue-500/50 hover:scale-110 hover:ring-blue-500 hover:shadow-md hover:shadow-blue-500/80 transition-all"
                     >
-                      <Brain className="mr-3 h-5 w-5" />{" "}
-                      <span className="text-lg">Memories</span>
-                    </DropdownMenuItem>
-                    <DropdownMenuItem
-                      onClick={openFeedbackModal}
-                      onPointerDown={triggerLightHaptic}
-                      className="flex items-center py-3"
-                    >
-                      <MessageCircle className="mr-3 h-5 w-5" />{" "}
-                      <span className="text-lg">Feedback</span>
-                    </DropdownMenuItem>
-                    <DropdownMenuItem
-                      onClick={openSettingsModal}
-                      onPointerDown={triggerLightHaptic}
-                      className="flex items-center py-3"
-                    >
-                      <Settings className="mr-3 h-5 w-5" />{" "}
-                      <span className="text-lg">Settings</span>
-                    </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
+                      <Brain className="h-5 w-5" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>Memories</TooltipContent>
+                </Tooltip>
               </div>
 
               <div className="flex items-center gap-1.5">

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { Brain, Settings } from "lucide-react"
+import { MessageCircle, Settings } from "lucide-react"
 import { useModal } from "@/hooks/useModal"
 import { Button } from "@/components/ui/button"
 import { Avatar, AvatarImage } from "@/components/ui/avatar"
@@ -8,12 +8,12 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip"
-import { DITTO_LOGO, BRAND_TEXT } from "@/constants"
+import { DITTO_LOGO } from "@/constants"
 import { cn } from "@/lib/utils"
 
 const TopBar: React.FC = () => {
   const modal = useModal()
-  const openMemoriesOverlay = modal.createOpenHandler("memories")
+  const openFeedbackModal = modal.createOpenHandler("feedback")
   const openSettingsModal = modal.createOpenHandler("settings")
 
   const topBarClasses = cn(
@@ -28,34 +28,31 @@ const TopBar: React.FC = () => {
 
   return (
     <header role="banner" className={topBarClasses}>
-      {/* Left - Memories Brain Icon */}
+      {/* Left - Feedback MessageCircle Icon */}
       <Tooltip>
         <TooltipTrigger asChild>
           <Button
             variant="ghost"
             size="icon"
-            onClick={openMemoriesOverlay}
-            aria-label="Open memories"
+            onClick={openFeedbackModal}
+            aria-label="Send feedback"
             className={iconButtonClasses}
           >
-            <Brain className="h-5 w-5 text-muted-foreground group-hover:text-foreground transition-colors" />
+            <MessageCircle className="h-5 w-5 text-muted-foreground group-hover:text-foreground transition-colors" />
           </Button>
         </TooltipTrigger>
-        <TooltipContent side="bottom">Memories</TooltipContent>
+        <TooltipContent side="bottom">Feedback</TooltipContent>
       </Tooltip>
 
-      {/* Center - Logo and Hey Ditto Text */}
-      <div className="absolute left-1/2 -translate-x-1/2 flex items-center gap-3">
-        <Avatar className="h-8 w-8">
+      {/* Center - Static Color-Changing Logo */}
+      <div className="absolute left-1/2 -translate-x-1/2">
+        <Avatar className="h-8 w-8 ring-1 ring-blue-500/70 shadow-sm shadow-blue-500/50">
           <AvatarImage
             src={DITTO_LOGO}
             alt="Ditto"
-            className="h-8 w-8 rounded-full"
+            className="h-8 w-8 rounded-full rainbow-gradient"
           />
         </Avatar>
-        <h1 className="text-lg font-medium text-foreground/90 tracking-wide">
-          {BRAND_TEXT}
-        </h1>
       </div>
 
       {/* Right - Settings Cog Icon */}

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { MessageCircle, Settings, Brain } from "lucide-react"
+import { MessageSquareWarning, Settings, Brain } from "lucide-react"
 import { useModal } from "@/hooks/useModal"
 import { Button } from "@/components/ui/button"
 import { Avatar, AvatarImage } from "@/components/ui/avatar"
@@ -42,7 +42,7 @@ const TopBar: React.FC = () => {
               aria-label="Send feedback"
               className={iconButtonClasses}
             >
-              <MessageCircle className="h-5 w-5 text-muted-foreground group-hover:text-foreground transition-colors" />
+              <MessageSquareWarning className="h-5 w-5 text-muted-foreground group-hover:text-foreground transition-colors" />
             </Button>
           </TooltipTrigger>
           <TooltipContent side="bottom">Feedback</TooltipContent>

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { MessageCircle, Settings } from "lucide-react"
+import { MessageCircle, Settings, Brain } from "lucide-react"
 import { useModal } from "@/hooks/useModal"
 import { Button } from "@/components/ui/button"
 import { Avatar, AvatarImage } from "@/components/ui/avatar"
@@ -11,10 +11,13 @@ import {
 import { DITTO_LOGO } from "@/constants"
 import { cn } from "@/lib/utils"
 
+const BRAND_TEXT = "Hey Ditto"
+
 const TopBar: React.FC = () => {
   const modal = useModal()
   const openFeedbackModal = modal.createOpenHandler("feedback")
   const openSettingsModal = modal.createOpenHandler("settings")
+  const openMemoriesModal = modal.createOpenHandler("memories")
 
   const topBarClasses = cn(
     "top-bar w-full bg-background/80 backdrop-blur-md border-b border-border/50",
@@ -28,24 +31,41 @@ const TopBar: React.FC = () => {
 
   return (
     <header role="banner" className={topBarClasses}>
-      {/* Left - Feedback MessageCircle Icon */}
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={openFeedbackModal}
-            aria-label="Send feedback"
-            className={iconButtonClasses}
-          >
-            <MessageCircle className="h-5 w-5 text-muted-foreground group-hover:text-foreground transition-colors" />
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent side="bottom">Feedback</TooltipContent>
-      </Tooltip>
+      {/* Left side - Feedback and Memories buttons */}
+      <div className="flex items-center gap-2">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={openFeedbackModal}
+              aria-label="Send feedback"
+              className={iconButtonClasses}
+            >
+              <MessageCircle className="h-5 w-5 text-muted-foreground group-hover:text-foreground transition-colors" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">Feedback</TooltipContent>
+        </Tooltip>
 
-      {/* Center - Static Color-Changing Logo */}
-      <div className="absolute left-1/2 -translate-x-1/2">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={openMemoriesModal}
+              aria-label="Open memories dashboard"
+              className={iconButtonClasses}
+            >
+              <Brain className="h-5 w-5 text-muted-foreground group-hover:text-foreground transition-colors" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">Memories</TooltipContent>
+        </Tooltip>
+      </div>
+
+      {/* Center - Logo and Brand Text */}
+      <div className="absolute left-1/2 -translate-x-1/2 flex items-center gap-3">
         <Avatar className="h-8 w-8 ring-1 ring-blue-500/70 shadow-sm shadow-blue-500/50">
           <AvatarImage
             src={DITTO_LOGO}
@@ -53,9 +73,12 @@ const TopBar: React.FC = () => {
             className="h-8 w-8 rounded-full rainbow-gradient"
           />
         </Avatar>
+        <span className="text-lg font-medium text-foreground select-none">
+          {BRAND_TEXT}
+        </span>
       </div>
 
-      {/* Right - Settings Cog Icon */}
+      {/* Right - Settings button */}
       <Tooltip>
         <TooltipTrigger asChild>
           <Button

--- a/src/components/WhatsNew/WhatsNew.tsx
+++ b/src/components/WhatsNew/WhatsNew.tsx
@@ -29,6 +29,7 @@ import V0_15_0 from "./versions/V0_15_0"
 import V0_15_1 from "./versions/V0_15_1"
 import V0_15_2 from "./versions/V0_15_2"
 import V0_15_3 from "./versions/V0_15_3"
+import V0_15_4 from "./versions/V0_15_4"
 // Add imports for future versions here
 
 // Map versions to their components
@@ -60,6 +61,7 @@ const versionComponents: Record<string, React.ComponentType> = {
   "0.15.1": V0_15_1,
   "0.15.2": V0_15_2,
   "0.15.3": V0_15_3,
+  "0.15.4": V0_15_4,
   // Add future versions here
 }
 

--- a/src/components/WhatsNew/versions/V0_15_4.tsx
+++ b/src/components/WhatsNew/versions/V0_15_4.tsx
@@ -1,0 +1,65 @@
+import { VersionSection, Section } from "./VersionTemplate"
+
+const sections: Section[] = [
+  {
+    title: "UI Layout Improvements",
+    features: [
+      {
+        type: "improved",
+        title: "Redesigned Top Bar",
+        description:
+          "Moved the animated Ditto logo to the top center and reorganized buttons - Feedback is now easily accessible on the top-left, while Settings remains on the top-right for a cleaner, more intuitive layout.",
+      },
+      {
+        type: "improved",
+        title: "Streamlined Chat Actions",
+        description:
+          "Chat message actions (Copy, Memories, Delete) are now integrated directly into message bubbles next to the Tags button, making them easier to find and use without cluttering the interface.",
+      },
+      {
+        type: "improved",
+        title: "Enhanced Bottom Bar",
+        description:
+          "Added a dedicated Memories button in the bottom center for quick access to your conversation history, while keeping the familiar Expand/Media buttons on the left and Send/Stop on the right.",
+      },
+    ],
+  },
+  {
+    title: "User Experience Enhancements",
+    features: [
+      {
+        type: "improved",
+        title: "Simplified Interface",
+        description:
+          "Removed redundant dropdown menus and made avatars purely visual, reducing cognitive load while preserving all functionality through more intuitive direct action buttons.",
+      },
+      {
+        type: "improved",
+        title: "Better Visual Consistency",
+        description:
+          "Maintained the beloved rainbow gradient animation on the Ditto logo while ensuring consistent button styling, hover effects, and spacing throughout the interface.",
+      },
+    ],
+  },
+  {
+    title: "Bug Fixes",
+    features: [
+      {
+        type: "fixed",
+        title: "Mobile Toast Positioning",
+        description:
+          "Fixed positioning issues with reward notifications on Android PWA, ensuring they appear correctly with proper spacing from the top of the screen.",
+      },
+    ],
+  },
+]
+
+const V0_15_4 = () => (
+  <div>
+    {sections.map((section, index) => (
+      <VersionSection key={index} {...section} />
+    ))}
+  </div>
+)
+
+export default V0_15_4

--- a/src/firebaseConfig.ts
+++ b/src/firebaseConfig.ts
@@ -1,5 +1,5 @@
-const MODE = import.meta.env.MODE
-// const MODE = "staging"
+// const MODE = import.meta.env.MODE
+const MODE = "staging"
 
 function getBaseURL(dittoEnv: string) {
   switch (dittoEnv) {

--- a/src/firebaseConfig.ts
+++ b/src/firebaseConfig.ts
@@ -1,5 +1,5 @@
-// const MODE = import.meta.env.MODE
-const MODE = "staging"
+const MODE = import.meta.env.MODE
+// const MODE = "staging"
 
 function getBaseURL(dittoEnv: string) {
   switch (dittoEnv) {


### PR DESCRIPTION
feat: Reorganize UI layout and improve UX

- Move animated Ditto dropdown menu from bottom center to top center
- Remove 'Hey Ditto' text from top bar for cleaner design
- Remove dropdown functionality from chat avatars (now purely visual)
- Move chat action buttons (copy, memories, delete) into chat bubbles
- Swap memories and feedback button positions for better UX
- Fix toast positioning for PWA vs web (dynamic offset)
- Preserve all rainbow gradient animations and styling