### PR TITLE
Done! The fix adds type casting (as BigFiveResultsType, as MBTIResult…

### DIFF
--- a/src/screens/PersonalityAssessments/PersonalityAssessmentOverlay.tsx
+++ b/src/screens/PersonalityAssessments/PersonalityAssessmentOverlay.tsx
@@ -558,7 +558,7 @@ export default function PersonalityAssessmentOverlay() {
       case "big-five":
         return (
           <BigFiveResults
-            results={assessment.results}
+            results={assessment.results as BigFiveResultsType}
             answers={assessment.answers}
             onBack={() => setSelectedAssessment(null)}
           />
@@ -566,7 +566,7 @@ export default function PersonalityAssessmentOverlay() {
       case "mbti":
         return (
           <MBTIResults
-            results={assessment.results}
+            results={assessment.results as MBTIResultsType}
             answers={assessment.answers}
             onBack={() => setSelectedAssessment(null)}
           />
@@ -574,7 +574,7 @@ export default function PersonalityAssessmentOverlay() {
       case "disc":
         return (
           <DISCResults
-            results={assessment.results}
+            results={assessment.results as DISCResultsType}
             answers={assessment.answers}
             onBack={() => setSelectedAssessment(null)}
           />


### PR DESCRIPTION
…sType, as DISCResultsType) to the results in renderAssessmentResults, matching the pattern you already used in renderInlineResults. This tells TypeScript which specific result type to expect in each case.