### PR TITLE
Fix console error: remove invalid menuMobile option from vis-network

### DIFF
--- a/src/screens/MemoriesDashboard/MemoriesNetworkGraph.tsx
+++ b/src/screens/MemoriesDashboard/MemoriesNetworkGraph.tsx
@@ -276,7 +276,6 @@ const MemoriesNetworkGraph: React.FC<MemoriesNetworkGraphProps> = ({
         },
         interaction: {
           dragNodes: true,
-          menuMobile: true,
           tooltipDelay: 200,
           hover: true,
           zoomView: true, // Enable zoom for all devices


### PR DESCRIPTION
Fixes console error in MemoriesNetworkGraph component by removing invalid `menuMobile` option from vis-network interaction configuration.

The `menuMobile` option is not a valid vis-network interaction setting and was causing repeated console warnings. All other interaction functionality remains intact.

Fixes #566

Generated with [Claude Code](https://claude.ai/code)