### PR TITLE
Add Memory Stats Module to system prompt with Top 15 subjects and descriptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ditto-pwa",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/src/api/memoryStats.ts
+++ b/src/api/memoryStats.ts
@@ -1,0 +1,57 @@
+import { getTopSubjects } from "@/api/kg"
+import { getConversationCount } from "@/api/userContent"
+import { Subject } from "@/types/common"
+
+export interface MemoryStatsParams {
+  totalMemoryCount: number
+  topSubjects: Subject[]
+}
+
+/**
+ * Fetches memory stats for a user synchronously
+ * @param userID - The user ID
+ * @param limit - Number of top subjects to fetch (default: 5)
+ * @returns Promise<MemoryStatsParams | null> - Returns null if there's an error or no memories
+ */
+export async function fetchMemoryStats(
+  userID: string,
+  limit: number = 5
+): Promise<MemoryStatsParams | null> {
+  try {
+    // Fetch both total memory count and top subjects in parallel
+    const [memoryCountResult, topSubjectsResult] = await Promise.all([
+      getConversationCount(userID),
+      getTopSubjects({ userID, limit }),
+    ])
+
+    // Handle memory count result
+    if (memoryCountResult instanceof Error) {
+      console.warn("Failed to fetch memory count:", memoryCountResult.message)
+      return null
+    }
+
+    const totalMemoryCount = memoryCountResult.count
+
+    // If user has 0 memories, return null (don't show module)
+    if (totalMemoryCount === 0) {
+      return null
+    }
+
+    // Handle top subjects result
+    let topSubjects: Subject[] = []
+    if (topSubjectsResult.err) {
+      console.warn("Failed to fetch top subjects:", topSubjectsResult.err)
+      // Continue with empty subjects rather than failing entirely
+    } else if (topSubjectsResult.ok) {
+      topSubjects = topSubjectsResult.ok.results
+    }
+
+    return {
+      totalMemoryCount,
+      topSubjects,
+    }
+  } catch (error) {
+    console.error("Error fetching memory stats:", error)
+    return null
+  }
+}

--- a/src/components/WhatsNew/WhatsNew.tsx
+++ b/src/components/WhatsNew/WhatsNew.tsx
@@ -40,6 +40,7 @@ import V0_16_3 from "./versions/V0_16_3"
 import V0_17_0 from "./versions/V0_17_0"
 import V0_17_1 from "./versions/V0_17_1"
 import V0_17_2 from "./versions/V0_17_2"
+import V0_17_3 from "./versions/V0_17_3"
 // Add imports for future versions here
 
 // Map versions to their components
@@ -82,6 +83,7 @@ const versionComponents: Record<string, React.ComponentType> = {
   "0.17.0": V0_17_0,
   "0.17.1": V0_17_1,
   "0.17.2": V0_17_2,
+  "0.17.3": V0_17_3,
   // Add future versions here
 }
 

--- a/src/components/WhatsNew/versions/V0_17_3.tsx
+++ b/src/components/WhatsNew/versions/V0_17_3.tsx
@@ -9,7 +9,7 @@ const sections: Section[] = [
         type: "new",
         title: "Memory Stats Module",
         description:
-          "Ditto now automatically includes your top 15 conversation subjects and memory count in the system prompt, helping the AI understand your interests and conversation patterns better. This intelligent context sharing improves response relevance without any action required from you.",
+          "Ditto is now automatically aware of your top conversation subjects, total memory count, and more, helping them understand your interests and conversation patterns better. This intelligent context sharing improves response relevance without any action required from you.",
       },
     ],
   },

--- a/src/components/WhatsNew/versions/V0_17_3.tsx
+++ b/src/components/WhatsNew/versions/V0_17_3.tsx
@@ -1,0 +1,43 @@
+import React from "react"
+import { VersionSection, Section } from "./VersionTemplate"
+
+const sections: Section[] = [
+  {
+    title: "New Features",
+    features: [
+      {
+        type: "new",
+        title: "Memory Stats Module",
+        description:
+          "Ditto now automatically includes your top 15 conversation subjects and memory count in the system prompt, helping the AI understand your interests and conversation patterns better. This intelligent context sharing improves response relevance without any action required from you.",
+      },
+    ],
+  },
+  {
+    title: "Improvements",
+    features: [
+      {
+        type: "improved",
+        title: "Enhanced Subject Context",
+        description:
+          "The system now provides richer subject information including descriptions when available, giving the AI deeper understanding of your conversation topics and improving the quality of responses.",
+      },
+      {
+        type: "improved",
+        title: "Developer Console Logging",
+        description:
+          "Added comprehensive logging for memory stats in development mode, making it easier to verify and debug the memory context system.",
+      },
+    ],
+  },
+]
+
+const V0_17_3 = () => (
+  <div>
+    {sections.map((section, index) => (
+      <VersionSection key={index} {...section} />
+    ))}
+  </div>
+)
+
+export default V0_17_3

--- a/src/components/WhatsNew/versions/V0_17_3.tsx
+++ b/src/components/WhatsNew/versions/V0_17_3.tsx
@@ -22,12 +22,6 @@ const sections: Section[] = [
         description:
           "The system now provides richer subject information including descriptions when available, giving the AI deeper understanding of your conversation topics and improving the quality of responses.",
       },
-      {
-        type: "improved",
-        title: "Developer Console Logging",
-        description:
-          "Added comprehensive logging for memory stats in development mode, making it easier to verify and debug the memory context system.",
-      },
     ],
   },
 ]

--- a/src/control/templates/mainTemplate.ts
+++ b/src/control/templates/mainTemplate.ts
@@ -50,7 +50,7 @@ export const systemTemplate = (params: {
   } = params
 
   let baseSystem =
-    "You are a friendly AI named Ditto here to help the user who is your best friend."
+    "You are a friendly AI named Ditto here to help the user who is your best friend. Respond conversationally before resorting to structure heavy responses. For example, do not use tables unless the user asks for something verbose. If they are just chatting with you do not respond in markdown."
 
   if (userID) {
     // Get personality information from localStorage

--- a/src/control/templates/mainTemplate.ts
+++ b/src/control/templates/mainTemplate.ts
@@ -1,6 +1,8 @@
 import { TOOLS } from "../../constants"
 import type { Tool, ToolPreferences } from "../../types/llm"
 import { PersonalityStorage } from "../../utils/personalityStorage"
+import { generateMemoryStatsSection } from "./memoryStatsTemplate"
+import type { MemoryStatsParams } from "../../api/memoryStats"
 
 const getToolsModule = (params: {
   toolPreferences: ToolPreferences
@@ -35,9 +37,17 @@ export const systemTemplate = (params: {
   firstName: string
   timestamp: string
   toolPreferences: ToolPreferences
+  memoryStats?: MemoryStatsParams
 }) => {
-  const { userID, memories, examples, firstName, timestamp, toolPreferences } =
-    params
+  const {
+    userID,
+    memories,
+    examples,
+    firstName,
+    timestamp,
+    toolPreferences,
+    memoryStats,
+  } = params
 
   let baseSystem =
     "You are a friendly AI named Ditto here to help the user who is your best friend."
@@ -97,9 +107,14 @@ export const systemTemplate = (params: {
   const currentTime =
     getTimezoneString() + " " + (new Date().getHours() >= 12 ? "PM" : "AM")
 
+  // Generate memory stats section if data is available
+  const memoryStatsSection = memoryStats
+    ? `\n\n${generateMemoryStatsSection(memoryStats)}`
+    : ""
+
   const systemPrompt = `${baseSystem}
 
-${toolsSection}${examplesSection}
+${toolsSection}${examplesSection}${memoryStatsSection}
 
 ## Context Information
 - User's Name: ${firstName}

--- a/src/control/templates/memoryStatsTemplate.ts
+++ b/src/control/templates/memoryStatsTemplate.ts
@@ -1,0 +1,37 @@
+import { Subject } from "@/types/common"
+import type { MemoryStatsParams } from "../../api/memoryStats"
+
+export const generateMemoryStatsSection = (
+  params: MemoryStatsParams
+): string => {
+  const { totalMemoryCount, topSubjects } = params
+
+  // Don't show the module if user has 0 memories
+  if (totalMemoryCount === 0) {
+    return ""
+  }
+
+  let section = `## Memory Stats Module
+
+You have access to ${totalMemoryCount} conversation memories that capture your interactions with ${params.totalMemoryCount > 1 ? "the user" : "this user"}.`
+
+  // Add top subjects section if we have subjects
+  if (topSubjects.length > 0) {
+    section += `\n\n### Top Memory Subjects\nHere are the main topics you've discussed together, ordered by frequency:\n`
+
+    topSubjects.forEach((subject, index) => {
+      const subjectLine = `${index + 1}. **${subject.subject_text}** (${subject.pair_count} conversation${subject.pair_count === 1 ? "" : "s"})`
+
+      // Add description if available
+      if (subject.description && subject.description.trim()) {
+        section += `\n${subjectLine}\n   - ${subject.description}`
+      } else {
+        section += `\n${subjectLine}`
+      }
+    })
+  }
+
+  section += `\n\nThese memory statistics help you understand the user's interests and conversation patterns.`
+
+  return section
+}

--- a/src/hooks/useMemoryStats.ts
+++ b/src/hooks/useMemoryStats.ts
@@ -1,0 +1,80 @@
+import { useState, useEffect } from "react"
+import { useAuth } from "./useAuth"
+import { getTopSubjects } from "@/api/kg"
+import { getConversationCount } from "@/api/userContent"
+import { Subject } from "@/types/common"
+
+export interface MemoryStats {
+  totalMemoryCount: number
+  topSubjects: Subject[]
+  loading: boolean
+  error: string | null
+}
+
+export function useMemoryStats(limit: number = 15): MemoryStats {
+  const { user } = useAuth()
+  const [totalMemoryCount, setTotalMemoryCount] = useState(0)
+  const [topSubjects, setTopSubjects] = useState<Subject[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!user?.uid) {
+      setLoading(false)
+      return
+    }
+
+    async function fetchMemoryStats() {
+      try {
+        setLoading(true)
+        setError(null)
+
+        // Fetch both total memory count and top subjects in parallel
+        const [memoryCountResult, topSubjectsResult] = await Promise.all([
+          getConversationCount(user!.uid),
+          getTopSubjects({ userID: user!.uid, limit }),
+        ])
+
+        // Handle memory count result
+        if (memoryCountResult instanceof Error) {
+          throw memoryCountResult
+        }
+        setTotalMemoryCount(memoryCountResult.count)
+
+        // Handle top subjects result
+        if (topSubjectsResult.err) {
+          console.warn("Failed to fetch top subjects:", topSubjectsResult.err)
+          setTopSubjects([])
+        } else if (topSubjectsResult.ok) {
+          setTopSubjects(topSubjectsResult.ok.results)
+        }
+      } catch (err) {
+        console.error("Error fetching memory stats:", err)
+        setError(
+          err instanceof Error ? err.message : "Failed to fetch memory stats"
+        )
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    fetchMemoryStats()
+
+    // Listen for memory-related events to refetch stats
+    const handleMemoryUpdate = () => fetchMemoryStats()
+    window.addEventListener("memoryUpdated", handleMemoryUpdate)
+    window.addEventListener("memoryDeleted", handleMemoryUpdate)
+
+    return () => {
+      window.removeEventListener("memoryUpdated", handleMemoryUpdate)
+      window.removeEventListener("memoryDeleted", handleMemoryUpdate)
+    }
+  }, [user?.uid, limit])
+
+  return {
+    totalMemoryCount,
+    topSubjects,
+    loading,
+    error,
+  }
+}

--- a/src/hooks/useMemoryStats.ts
+++ b/src/hooks/useMemoryStats.ts
@@ -1,4 +1,3 @@
-import { useEffect } from "react"
 import { useAuth } from "./useAuth"
 import { getTopSubjects } from "@/api/kg"
 import { getConversationCount } from "@/api/userContent"
@@ -22,6 +21,9 @@ export function useMemoryStats(limit: number = 15): MemoryStats {
     queryKey: ["memory-stats", user?.uid, limit],
     enabled: !!user?.uid,
     staleTime: 60 * 1000, // 1 minute cache
+    refetchOnMount: "always",
+    refetchOnWindowFocus: true,
+    refetchOnReconnect: true,
     queryFn: async () => {
       if (!user?.uid) {
         return { totalMemoryCount: 0, topSubjects: [] }
@@ -51,24 +53,6 @@ export function useMemoryStats(limit: number = 15): MemoryStats {
     },
   })
 
-  // Attach event listeners to refetch on memory updates/deletes
-  useEffect(() => {
-    if (!user?.uid) return
-
-    const handleMemoryUpdate = () => {
-      // Soft refetch
-      query.refetch()
-    }
-
-    window.addEventListener("memoryUpdated", handleMemoryUpdate)
-    window.addEventListener("memoryDeleted", handleMemoryUpdate)
-
-    return () => {
-      window.removeEventListener("memoryUpdated", handleMemoryUpdate)
-      window.removeEventListener("memoryDeleted", handleMemoryUpdate)
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [user?.uid, limit])
 
   return {
     totalMemoryCount: query.data?.totalMemoryCount ?? 0,

--- a/src/hooks/useMemoryStats.ts
+++ b/src/hooks/useMemoryStats.ts
@@ -1,8 +1,9 @@
-import { useState, useEffect } from "react"
+import { useEffect } from "react"
 import { useAuth } from "./useAuth"
 import { getTopSubjects } from "@/api/kg"
 import { getConversationCount } from "@/api/userContent"
 import { Subject } from "@/types/common"
+import { useQuery } from "@tanstack/react-query"
 
 export interface MemoryStats {
   totalMemoryCount: number
@@ -13,55 +14,52 @@ export interface MemoryStats {
 
 export function useMemoryStats(limit: number = 15): MemoryStats {
   const { user } = useAuth()
-  const [totalMemoryCount, setTotalMemoryCount] = useState(0)
-  const [topSubjects, setTopSubjects] = useState<Subject[]>([])
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
 
-  useEffect(() => {
-    if (!user?.uid) {
-      setLoading(false)
-      return
-    }
-
-    async function fetchMemoryStats() {
-      try {
-        setLoading(true)
-        setError(null)
-
-        // Fetch both total memory count and top subjects in parallel
-        const [memoryCountResult, topSubjectsResult] = await Promise.all([
-          getConversationCount(user!.uid),
-          getTopSubjects({ userID: user!.uid, limit }),
-        ])
-
-        // Handle memory count result
-        if (memoryCountResult instanceof Error) {
-          throw memoryCountResult
-        }
-        setTotalMemoryCount(memoryCountResult.count)
-
-        // Handle top subjects result
-        if (topSubjectsResult.err) {
-          console.warn("Failed to fetch top subjects:", topSubjectsResult.err)
-          setTopSubjects([])
-        } else if (topSubjectsResult.ok) {
-          setTopSubjects(topSubjectsResult.ok.results)
-        }
-      } catch (err) {
-        console.error("Error fetching memory stats:", err)
-        setError(
-          err instanceof Error ? err.message : "Failed to fetch memory stats"
-        )
-      } finally {
-        setLoading(false)
+  const query = useQuery<
+    { totalMemoryCount: number; topSubjects: Subject[] },
+    Error
+  >({
+    queryKey: ["memory-stats", user?.uid, limit],
+    enabled: !!user?.uid,
+    staleTime: 60 * 1000, // 1 minute cache
+    queryFn: async () => {
+      if (!user?.uid) {
+        return { totalMemoryCount: 0, topSubjects: [] }
       }
+
+      const [memoryCountResult, topSubjectsResult] = await Promise.all([
+        getConversationCount(user.uid),
+        getTopSubjects({ userID: user.uid, limit }),
+      ])
+
+      if (memoryCountResult instanceof Error) {
+        throw memoryCountResult
+      }
+
+      let topSubjects: Subject[] = []
+      if (topSubjectsResult.err) {
+        // Don't fail the whole query if subjects fail; log and continue
+        console.warn("Failed to fetch top subjects:", topSubjectsResult.err)
+      } else if (topSubjectsResult.ok) {
+        topSubjects = topSubjectsResult.ok.results
+      }
+
+      return {
+        totalMemoryCount: memoryCountResult.count,
+        topSubjects,
+      }
+    },
+  })
+
+  // Attach event listeners to refetch on memory updates/deletes
+  useEffect(() => {
+    if (!user?.uid) return
+
+    const handleMemoryUpdate = () => {
+      // Soft refetch
+      query.refetch()
     }
 
-    fetchMemoryStats()
-
-    // Listen for memory-related events to refetch stats
-    const handleMemoryUpdate = () => fetchMemoryStats()
     window.addEventListener("memoryUpdated", handleMemoryUpdate)
     window.addEventListener("memoryDeleted", handleMemoryUpdate)
 
@@ -69,12 +67,13 @@ export function useMemoryStats(limit: number = 15): MemoryStats {
       window.removeEventListener("memoryUpdated", handleMemoryUpdate)
       window.removeEventListener("memoryDeleted", handleMemoryUpdate)
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [user?.uid, limit])
 
   return {
-    totalMemoryCount,
-    topSubjects,
-    loading,
-    error,
+    totalMemoryCount: query.data?.totalMemoryCount ?? 0,
+    topSubjects: query.data?.topSubjects ?? [],
+    loading: query.isLoading,
+    error: query.error ? query.error.message : null,
   }
 }

--- a/src/hooks/useMemoryStats.ts
+++ b/src/hooks/useMemoryStats.ts
@@ -53,7 +53,6 @@ export function useMemoryStats(limit: number = 15): MemoryStats {
     },
   })
 
-
   return {
     totalMemoryCount: query.data?.totalMemoryCount ?? 0,
     topSubjects: query.data?.topSubjects ?? [],


### PR DESCRIPTION
## Summary
- Introduces a Memory Stats Module injected into the system prompt, showing:
  - Total memory count
  - Top 15 subjects (by conversation count)
  - Subject descriptions (when available)
- Adds a green dev console log of the Memory Stats Module to verify without reading the full prompt
- Hides the module automatically if the user has 0 memories
- Avoids any search-based endpoints; uses only top subjects and existing memory count

## Frontend Changes (ditto-app)
- New: `src/hooks/useMemoryStats.ts`
  - Fetches total memory count and top subjects in parallel
  - Listens to `memoryUpdated`/`memoryDeleted` events to refresh
  - Defaults to limit 15
- New: `src/api/memoryStats.ts`
  - `fetchMemoryStats(userID, limit)` returns `{ totalMemoryCount, topSubjects } | null`
- New: `src/control/templates/memoryStatsTemplate.ts`
  - `generateMemoryStatsSection(params)` creates formatted Memory Stats output
- Updated: `src/control/templates/mainTemplate.ts`
  - Accepts optional `memoryStats` and injects Memory Stats section when present
- Updated: `src/control/agent.js`
  - Fetches memory stats in parallel with other pre-prompt requests
  - Passes `memoryStats` into `systemTemplate`
  - Logs Memory Stats Module in green above the orange system prompt output (dev only)
  - Increased subject limit from 5 to 15 for the Memory Stats Module

## Backend Changes (agentic-pipelines)
- Updated: `modules/pg_queries.py`
  - `get_top_subjects_by_pair_count_pg` now selects `s.description_text` in addition to `id`, `subject_text`, `pair_count`
- Updated: `main.py` `/kg/subjects/top`
  - Returns `description` mapped from `description_text` and includes `is_key_subject: true`
  - No change in request shape; response now includes `description`

## API/Contracts
- Frontend expects `/kg/subjects/top` response items to include:
  - `id`, `subject_text`, `pair_count`, `description?`, `is_key_subject?`
- No breaking changes introduced for existing usage

## Behavior
- If total memory count is 0:
  - Memory Stats Module is not shown
  - Dev console logs: “[MemoryStats] No memory stats available …”
- If `/kg/subjects/top` fails:
  - Module renders without subjects (still shows total count if available)
  - Dev console logs a warning
- Descriptions are displayed when present

## Dev Console Logging (for quick validation)
- Green: Memory Stats Module or a concise message if unavailable
- Orange: Full system prompt
- Green: User prompt

## Testing Steps
1. Ensure user has > 0 memories (and ideally multiple subjects).
2. Dev mode: open browser console.
3. Send a prompt to Ditto.
4. Verify:
   - Green console shows Memory Stats Module with “Top 15” subjects.
   - If backend updated: subjects include descriptions.
   - Orange console shows the full system prompt.
5. Test 0-memory user: module should not appear; green log should indicate unavailability.

## Deployment Notes
- Frontend: no special steps
- Backend: Deploy `agentic-pipelines` for `/kg/subjects/top` to include `description`
  - Without this deploy, subjects appear without descriptions

## Performance
- Adds one parallel call (`/kg/subjects/top`) during prompt orchestration
- Limited to top 15 to bound payload size

## Security
- All KG endpoints use Firebase token verification
- No new sensitive data exposed

## Risks/Limitations
- Very long descriptions could expand prompt size (future: consider truncation)
- If backend not deployed, descriptions won’t be present (safe fallback)

## Follow-ups (optional)
- Truncate or summarize long subject descriptions
- Add caching layer for top subjects to reduce repeated calls
- Surface subject types or additional metadata if available